### PR TITLE
Expose Dagre layout config

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,10 @@
           <textarea v-model="linksData" @blur="parseLinks" class="w-full text-sm" rows="10"></textarea>
         </label>
 
+        <label>
+          <textarea v-model="layoutCfgData" @blur="parseLayoutConfig" class="w-full text-sm" rows="10"></textarea>
+        </label>
+
         <div>
           Events:
           <ul class="bg-white h-48 overflow-y-scroll text-sm font-mono">
@@ -32,6 +36,7 @@
         :links="links"
         :active-links="activeLinks"
         :auto-zoom="autoZoom"
+        :layout-cfg="layoutCfg"
         @link-enter="onLinkEnter"
         @link-out="onLinkOut"
       >
@@ -92,6 +97,20 @@ export default {
     }
     onMounted(parseLinks)
 
+    const layoutCfgData = ref(JSON.stringify({
+      rankdir: 'RL',
+      align: undefined,
+      nodesep: 20,
+      ranksep: 50,
+      marginx: 10,
+      marginy: 10,
+    }, null, 2))
+    const layoutCfg = ref([])
+    const parseLayoutConfig = () => {
+      layoutCfg.value = JSON.parse(layoutCfgData.value)
+    }
+    onMounted(parseLayoutConfig)
+
     const events = ref([])
     const activeLinks = ref([])
     const onLinkEnter = (link) => {
@@ -112,6 +131,9 @@ export default {
       linksData,
       links,
       parseLinks,
+      layoutCfgData,
+      layoutCfg,
+      parseLayoutConfig,
       activeLinks,
       onLinkEnter,
       onLinkOut,

--- a/src/components/GraphLayout.vue
+++ b/src/components/GraphLayout.vue
@@ -83,6 +83,18 @@ export default {
     activeLinks: { required: true, type: Array },
     // Adjust zoom level when nodes change
     autoZoom: { default: true },
+    layoutCfg: {
+      // Full description at
+      // https://g6.antv.vision/en/docs/api/graphLayout/dagre
+      default: {
+        rankdir: 'RL',
+        align: undefined,
+        nodesep: 20,
+        ranksep: 50,
+        marginx: 10,
+        marginy: 10,
+      }
+    }
   },
   emits: ['link-enter', 'link-out'],
 
@@ -92,6 +104,9 @@ export default {
 
   watch: {
     nodes () {
+      this.renderGraph()
+    },
+    layoutCfg () {
       this.renderGraph()
     }
   },
@@ -110,7 +125,7 @@ export default {
       const nodes = this.nodes.map(node => ({ ...node }))
       const links = this.links.map(link => ({ ...link }))
 
-      const layout = computeLayout(root, nodes, links)
+      const layout = computeLayout(root, nodes, links, this.layoutCfg)
       const simulation = d3.forceSimulation().nodes(nodes)
 
       simulation
@@ -292,17 +307,10 @@ function nearestPointOnPerimeter (point, rectTopLeft, rectWidth, rectHeight) {
 }
 
 // Compute graph layout using Dagre
-function computeLayout (root, nodes, links) {
+function computeLayout (root, nodes, links, layoutCfg) {
   const g = new dagre.graphlib.Graph()
 
-  g.setGraph({
-    rankdir: 'RL',
-    // align: 'DL',
-    nodesep: 20,
-    ranksep: 50,
-    marginx: 10,
-    marginy: 10,
-  })
+  g.setGraph(layoutCfg)
 
   // Default to assigning a new object as a label for each new edge.
   g.setDefaultEdgeLabel(() => ({}))


### PR DESCRIPTION
It allows specifying layout properties such as Left to Right, margins, and separation between nodes.

```js
    // https://g6.antv.vision/en/docs/api/graphLayout/dagre
    default: {
      rankdir: 'RL',
      align: undefined,
      nodesep: 20,
      ranksep: 50,
      marginx: 10,
      marginy: 10,
    }
```